### PR TITLE
feat(docs): SCRUM-53 Implement and configure API documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ db.sqlite3
 
 .pytest_cache/
 .coverage
+schema.json

--- a/config/settings.py
+++ b/config/settings.py
@@ -203,3 +203,19 @@ SOCIALACCOUNT_PROVIDERS = {
         },
     }
 }
+
+# DRF-Spectacular
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Charity Platform API",
+    "DESCRIPTION": "Документація для API благодійної платформи. Тут ви знайдете всі ендпоінти для взаємодії з бекендом.",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    # dj-rest-auth
+    "SWAGGER_UI_SETTINGS": {
+        "deepLinking": True,
+    },
+    "PREPROCESSING_HOOKS": ["core.spectacular_hooks.pre_processing_hook"],
+    "POSTPROCESSING_HOOKS": [
+        "drf_spectacular.hooks.postprocess_schema_enums",
+    ],
+}

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,15 +2,23 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
-from users.views import GoogleLogin, CustomRegisterView
-from users.views import CurrentUserView
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
+from users.views import GoogleLogin, CustomRegisterView, CurrentUserView
 
 urlpatterns = [
+    # Admin URL
     path("admin/", admin.site.urls),
-    path("api/v1/projects", include("projects.urls")),
-    path("api/v1/users", include("users.urls")),
-    path("api/v1/me/", CurrentUserView.as_view(), name="current-user"),
+    # Apps
+    path("api/v1/projects/", include("projects.urls")),
+    path("api/v1/users/", include("users.urls")),
     # Authentication URLs
+    path(
+        "api/v1/auth/user/", CurrentUserView.as_view(), name="rest_user_details"
+    ),
     path("api/v1/auth/", include("dj_rest_auth.urls")),
     path(
         "api/v1/auth/registration/",
@@ -19,7 +27,22 @@ urlpatterns = [
     ),
     # Google Login URL
     path("api/v1/auth/google/", GoogleLogin.as_view(), name="google_login"),
+    # API
+    path("api/v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    # Swagger UI:
+    path(
+        "api/v1/docs/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    # ReDoc:
+    path(
+        "api/v1/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
 ]
+
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/core/spectacular_hooks.py
+++ b/core/spectacular_hooks.py
@@ -1,0 +1,38 @@
+from drf_spectacular.utils import extend_schema
+from dj_rest_auth.views import UserDetailsView
+
+
+def pre_processing_hook(endpoints):
+    """
+    Цей хук виконує дві дії:
+    1. Видаляє стандартний ендпоінт /auth/user/ від dj-rest-auth з документації.(Уникаємо дублювання)
+    2. Групує решту ендпоінтів dj-rest-auth під тегом 'Authentication'.
+    """
+
+    filtered_endpoints = []
+    for path, path_regex, method, callback in endpoints:
+        if (
+            hasattr(callback, "view_class")
+            and callback.view_class is UserDetailsView
+        ):
+            continue
+
+        filtered_endpoints.append((path, path_regex, method, callback))
+
+    auth_paths = [
+        "/api/v1/auth/login/",
+        "/api/v1/auth/logout/",
+        "/api/v1/auth/password/change/",
+        "/api/v1/auth/password/reset/",
+        "/api/v1/auth/password/reset/confirm/",
+        "/api/v1/auth/token/verify/",
+        "/api/v1/auth/token/refresh/",
+    ]
+
+    for path, path_regex, method, callback in filtered_endpoints:
+        if hasattr(callback, "view_class") and path in auth_paths:
+            callback.view_class = extend_schema(tags=["Authentication"])(
+                callback.view_class
+            )
+
+    return filtered_endpoints

--- a/projects/serializers.py
+++ b/projects/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from .models import Category, Project, ProjectImage
 from users.models import CustomUser
+from drf_spectacular.utils import extend_schema_field
 
 
 class CategorySerializer(serializers.ModelSerializer):
@@ -40,6 +41,7 @@ class ProjectListSerializer(serializers.ModelSerializer):
             "end_date",
         ]
 
+    @extend_schema_field(serializers.URLField())
     def get_cover_image(self, obj):
         first_image = obj.images.first()
         if first_image:

--- a/projects/urls.py
+++ b/projects/urls.py
@@ -1,8 +1,11 @@
+from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from .views import CategoryViewSet, ProjectViewSet
 
 router = DefaultRouter()
 router.register(r"categories", CategoryViewSet, basename="category")
-router.register(r"projects", ProjectViewSet, basename="project")
+router.register(r"", ProjectViewSet, basename="project")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/projects/views.py
+++ b/projects/views.py
@@ -5,10 +5,22 @@ from .serializers import (
     CategorySerializer,
     ProjectListSerializer,
     ProjectDetailSerializer,
-    ProjectImageSerializer,
+)
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiParameter,
+    extend_schema_view,
 )
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="Отримати список категорій", tags=["Categories"]
+    ),
+    retrieve=extend_schema(
+        summary="Отримати деталі категорії", tags=["Categories"]
+    ),
+)
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Category.objects.all().order_by("name")
     serializer_class = CategorySerializer
@@ -26,6 +38,33 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
         return obj.author == request.user
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="Отримати список активних проєктів",
+        description="Повертає список проєктів зі статусом 'active'. Можна фільтрувати за ID категорії.",
+        parameters=[
+            OpenApiParameter(
+                name="category",
+                description="Фільтрувати за ID категорії",
+                type=int,
+            ),
+        ],
+        tags=["Projects"],
+    ),
+    retrieve=extend_schema(
+        summary="Отримати деталі проєкту", tags=["Projects"]
+    ),
+    create=extend_schema(
+        summary="Створити новий проєкт",
+        description="Створює проєкт, який одразу стає активним. Потрібна аутентифікація.",
+        tags=["Projects"],
+    ),
+    update=extend_schema(summary="Повністю оновити проєкт", tags=["Projects"]),
+    partial_update=extend_schema(
+        summary="Частково оновити проєкт", tags=["Projects"]
+    ),
+    destroy=extend_schema(summary="Видалити проєкт", tags=["Projects"]),
+)
 class ProjectViewSet(viewsets.ModelViewSet):
     """
     ViewSet for projects.

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,5 +1,3 @@
-# users/serializers.py
-
 from rest_framework import serializers
 from django.contrib.auth import get_user_model
 from projects.serializers import CategorySerializer

--- a/users/urls.py
+++ b/users/urls.py
@@ -6,6 +6,5 @@ router = DefaultRouter()
 router.register(r"authors", AuthorViewSet, basename="author")
 
 urlpatterns = [
-    # path("me/", CurrentUserView.as_view(), name="current-user"),
     path("", include(router.urls)),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -13,8 +13,19 @@ from dj_rest_auth.utils import jwt_encode
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
 from dj_rest_auth.registration.views import SocialLoginView
+from drf_spectacular.utils import extend_schema_view, extend_schema
 
 
+@extend_schema_view(
+    list=extend_schema(
+        summary="Отримати список авторів",
+        description="Повертає список авторів, у яких є хоча б один активний проєкт.",
+        tags=["Authors"],
+    ),
+    retrieve=extend_schema(
+        summary="Отримати публічний профіль автора", tags=["Authors"]
+    ),
+)
 class AuthorViewSet(viewsets.ReadOnlyModelViewSet):
     """
     ViewSet for view public author profile.
@@ -42,6 +53,11 @@ class AuthorViewSet(viewsets.ReadOnlyModelViewSet):
         return super().get_serializer_class()
 
 
+@extend_schema(
+    summary="Отримати або оновити свій профіль",
+    description="Дозволяє залогіненому користувачу переглянути та відредагувати свій профіль.",
+    tags=["Profile (Me)"],
+)
 class CurrentUserView(generics.RetrieveAPIView):
     """
     View for retrieving the current user's profile.
@@ -55,6 +71,11 @@ class CurrentUserView(generics.RetrieveAPIView):
         return self.request.user
 
 
+@extend_schema(
+    summary="Вхід через Google",
+    description="Приймає `access_token` від Google, створює/логінить користувача і повертає JWT токени.",
+    tags=["Authentication"],
+)
 class GoogleLogin(SocialLoginView):
     """
     View for Google OAuth2 login.
@@ -67,6 +88,11 @@ class GoogleLogin(SocialLoginView):
     client_class = OAuth2Client
 
 
+@extend_schema(
+    summary="Реєстрація нового користувача",
+    description="Створює нового користувача за email та паролем. Повертає JWT токени.",
+    tags=["Authentication"],
+)
 class CustomRegisterView(generics.CreateAPIView):
     serializer_class = CustomRegisterSerializer
     permission_classes = [permissions.AllowAny]


### PR DESCRIPTION
- Installed and configured drf-spectacular to generate OpenAPI 3 schema.
- Added Swagger UI and ReDoc endpoints at /api/docs/ and /api/redoc/.
- Decorated all major ViewSets and Views with @extend_schema to provide clear summaries, descriptions, and tags.
- Implemented a pre-processing hook to group dj-rest-auth endpoints under a single 'Authentication' tag and to remove duplicated views from the documentation.
- Resolved all configuration issues and warnings related to schema generation.
- Refactored URL patterns for better readability and RESTful structure (e.g., /api/v1/projects/categories/).
- The API is now fully documented and ready for frontend integration."