### PR TITLE
test(api): SCRUM-57 Add unit tests for custom functionality

### DIFF
--- a/projects/tests.py
+++ b/projects/tests.py
@@ -1,3 +1,120 @@
-from django.test import TestCase
+import pytest
+from rest_framework.test import APIClient
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from .models import Project, Category
 
-# Create your tests here.
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def create_user(db):
+    def user_factory(**kwargs):
+        return User.objects.create_user(**kwargs)
+
+    return user_factory
+
+
+@pytest.fixture
+def create_category(db):
+    return Category.objects.create(name="Test Category", slug="test-category")
+
+
+@pytest.fixture
+def create_project(db, create_user, create_category):
+    user = create_user(email="author@test.com", password="password123")
+    return Project.objects.create(
+        author=user,
+        category=create_category,
+        title="Test Project",
+        description="Test Description",
+        fundraising_goal="Test Goal",
+        donation_type="full_price",
+        price="100.00",
+    )
+
+
+@pytest.mark.django_db
+def test_project_update_by_owner(api_client, create_project):
+    project = create_project
+    owner = project.author
+    api_client.force_authenticate(user=owner)
+
+    updated_data = {"title": "Updated Title"}
+    response = api_client.patch(
+        f"/api/v1/projects/{project.id}/", updated_data, format="json"
+    )
+
+    assert response.status_code == 200
+    project.refresh_from_db()
+    assert project.title == "Updated Title"
+
+
+@pytest.mark.django_db
+def test_project_update_by_another_user_forbidden(
+    api_client, create_project, create_user
+):
+    project = create_project
+    another_user = create_user(email="another@test.com", password="password123")
+    api_client.force_authenticate(user=another_user)
+
+    updated_data = {"title": "Forbidden Update"}
+    response = api_client.patch(
+        f"/api/v1/projects/{project.id}/", updated_data, format="json"
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_project_delete_by_owner(api_client, create_project):
+    project = create_project
+    owner = project.author
+    api_client.force_authenticate(user=owner)
+
+    response = api_client.delete(f"/api/v1/projects/{project.id}/")
+
+    assert response.status_code == 204
+    assert not Project.objects.filter(id=project.id).exists()
+
+
+@pytest.mark.django_db
+def test_project_delete_by_another_user_forbidden(
+    api_client, create_project, create_user
+):
+    project = create_project
+    another_user = create_user(email="another@test.com", password="password123")
+    api_client.force_authenticate(user=another_user)
+
+    response = api_client.delete(f"/api/v1/projects/{project.id}/")
+
+    assert response.status_code == 403
+    assert Project.objects.filter(id=project.id).exists()
+
+
+@pytest.mark.django_db
+def test_upload_image_to_project_by_owner(api_client, create_project):
+    project = create_project
+    owner = project.author
+    api_client.force_authenticate(user=owner)
+
+    image_content = b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b"
+    image = SimpleUploadedFile(
+        "test_image.jpeg", image_content, content_type="image/jpeg"
+    )
+
+    response = api_client.post(
+        f"/api/v1/projects/{project.id}/upload-image/",
+        {"image": image},
+        format="multipart",
+    )
+
+    assert response.status_code == 201
+    project.refresh_from_db()
+    assert project.images.count() == 1
+    assert project.images.first().image.name.endswith(".webp")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = config.settings
+python_files = tests.py test_*.py *_tests.py
+
+# Ігноруємо попередження про застарілі налаштування від dj_rest_auth
+filterwarnings =
+    ignore:.*app_settings.USERNAME_REQUIRED is deprecated.*:UserWarning
+    ignore:.*app_settings.EMAIL_REQUIRED is deprecated.*:UserWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,10 @@ django-storages==1.14.6
 djangorestframework==3.16.0
 djangorestframework_simplejwt==5.5.0
 drf-spectacular==0.28.0
+exceptiongroup==1.3.0
 idna==3.10
 inflection==0.5.1
+iniconfig==2.1.0
 jmespath==1.0.1
 jsonschema==4.24.0
 jsonschema-specifications==2025.4.1
@@ -30,11 +32,15 @@ pathspec==0.12.1
 pilkit==3.0
 pillow==11.3.0
 platformdirs==4.3.8
+pluggy==1.6.0
 psycopg2-binary==2.9.10
 pycodestyle==2.14.0
 pycparser==2.22
 pyflakes==3.4.0
+Pygments==2.19.2
 PyJWT==2.9.0
+pytest==8.4.1
+pytest-django==4.11.1
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.1
 PyYAML==6.0.2

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,117 @@
-from django.test import TestCase
+import pytest
+from rest_framework.test import APIClient
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+import os
 
-# Create your tests here.
+
+@pytest.fixture
+def create_user(
+    db,
+):
+    def user_factory(**kwargs):
+        return User.objects.create_user(**kwargs)
+
+    return user_factory
+
+
+User = get_user_model()
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def registration_data():
+    return {
+        "email": "test@example.com",
+        "password": "some_strong_password_123",
+        "password2": "some_strong_password_123",
+    }
+
+
+@pytest.mark.django_db
+def test_successful_registration(api_client, registration_data):
+    response = api_client.post(
+        "/api/v1/auth/registration/", registration_data, format="json"
+    )
+
+    assert response.status_code == 201
+    assert User.objects.count() == 1
+
+    new_user = User.objects.first()
+    assert new_user.email == registration_data["email"]
+
+    response_data = response.json()
+    assert "access" in response_data
+    assert "refresh" in response_data
+
+
+@pytest.mark.django_db
+def test_registration_passwords_mismatch(api_client):
+    data = {
+        "email": "test@example.com",
+        "password": "password123",
+        "password2": "password456",
+    }
+
+    response = api_client.post(
+        "/api/v1/auth/registration/", data, format="json"
+    )
+
+    assert response.status_code == 400
+    assert User.objects.count() == 0
+    assert "password" in response.json()
+
+
+@pytest.mark.django_db
+def test_registration_duplicate_email(api_client, registration_data):
+    User.objects.create_user(
+        email=registration_data["email"], password=registration_data["password"]
+    )
+
+    assert User.objects.count() == 1
+
+    response = api_client.post(
+        "/api/v1/auth/registration/", registration_data, format="json"
+    )
+
+    assert response.status_code == 400
+    assert User.objects.count() == 1
+    assert "email" in response.json()
+
+
+@pytest.mark.django_db
+def test_avatar_upload_authenticated_user(api_client, create_user):
+
+    user = create_user(email="user@test.com", password="password123")
+    api_client.force_authenticate(user=user)
+
+    avatar_content = b"\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff\x00\x00\x00\x2c\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02\x44\x01\x00\x3b"
+    avatar = SimpleUploadedFile(
+        "test_avatar.jpg", avatar_content, content_type="image/jpg"
+    )
+
+    response = api_client.put(
+        "/api/v1/auth/user/avatar/", {"avatar": avatar}, format="multipart"
+    )
+
+    assert response.status_code == 200
+
+    user.refresh_from_db()
+    assert user.avatar is not None
+    assert user.avatar.name.endswith(".webp")
+
+
+@pytest.mark.django_db
+def test_avatar_upload_unauthenticated_user(api_client):
+    avatar_content = b"test content"
+    avatar = SimpleUploadedFile("test.txt", avatar_content)
+
+    response = api_client.put(
+        "/api/v1/auth/user/avatar/", {"avatar": avatar}, format="multipart"
+    )
+
+    assert response.status_code == 401


### PR DESCRIPTION
- Integrated pytest and pytest-django for testing the application.
- Added a pytest.ini configuration file to define settings and filter warnings.
- Wrote unit tests for the custom user registration endpoint, covering successful registration, password mismatch, and duplicate email scenarios.
- Implemented tests for the avatar upload functionality, checking both authenticated and unauthenticated access.
- Added tests for the ProjectViewSet to verify the custom IsOwnerOrReadOnly permission for update and delete operations.
- Wrote a test for the project image upload endpoint to ensure functionality for authenticated project owners.
- All tests are passing, ensuring the stability and correctness of the core custom logic.